### PR TITLE
feat(network): export Request class for extension

### DIFF
--- a/packages/network/lib/network_y.dart
+++ b/packages/network/lib/network_y.dart
@@ -1,4 +1,4 @@
 export 'src/client/api_client.dart';
 export 'src/client/executors/executors.dart';
 export 'src/exceptions/api_exception.dart';
-export 'src/request/request.dart' hide Request;
+export 'src/request/request.dart';


### PR DESCRIPTION
## Summary

- Export the `Request` class from `network_y` package to allow extending it in consuming projects
- Previously `Request` was hidden from exports, preventing inheritance patterns like:

```dart
class FunctionsRequest extends Request {
  FunctionsRequest({required super.endpoint}) : super(
    baseUrl: 'https://...',
    headers: {...},
  );
}
```

## Test plan

- [x] Verify `Request` is now importable from `network_y`
- [x] Tested in stow project with `FunctionsRequest` extending `Request`